### PR TITLE
feat:[MR-97] send appVersion as payload metadata

### DIFF
--- a/src/android-interface/android-interface.spec.ts
+++ b/src/android-interface/android-interface.spec.ts
@@ -134,4 +134,54 @@ describe('Feature: Android Interface', () => {
       expect(payload.options).toEqual(options);
     });
   });
+
+  describe('Scenario: Constructor-driven metadata', () => {
+    test('should attach constructor metadata to summary_data payloads', () => {
+      // Given the interface is constructed with metadata
+      androidInterface = new AndroidInterface({
+        app_id: 'com.example.app',
+        cr_user_id: 'user-123',
+        metadata: { appVersion: 'v1.2.3' }
+      });
+
+      // When a summary event is logged without passing metadata per call
+      androidInterface.logSummaryData({ event: 'level_complete' });
+
+      // Then the payload carries the metadata at the top level
+      const payload = JSON.parse(mockLogMessage.mock.calls[0][0]);
+      expect(payload.metadata).toEqual({ appVersion: 'v1.2.3' });
+    });
+
+    test('should attach constructor metadata to user_sessions_data payloads', () => {
+      // Given the interface is constructed with metadata
+      androidInterface = new AndroidInterface({
+        app_id: 'com.example.app',
+        cr_user_id: 'user-123',
+        metadata: { appVersion: 'v1.2.3' }
+      });
+
+      // When a user session event is logged without passing metadata per call
+      androidInterface.logUserSessionsData({ session_id: 'sess-abc' });
+
+      // Then the payload carries the metadata at the top level
+      const payload = JSON.parse(mockLogMessage.mock.calls[0][0]);
+      expect(payload.metadata).toEqual({ appVersion: 'v1.2.3' });
+    });
+
+    test('should omit metadata key entirely when not provided', () => {
+      // Given the interface is constructed without metadata
+      androidInterface = new AndroidInterface({
+        app_id: 'com.example.app',
+        cr_user_id: 'user-123',
+      });
+
+      // When an event is logged
+      androidInterface.logSummaryData({ event: 'test' });
+
+      // Then the serialized payload has no metadata key (backward compatible)
+      const payloadJson = mockLogMessage.mock.calls[0][0];
+      const payload = JSON.parse(payloadJson);
+      expect(payload).not.toHaveProperty('metadata');
+    });
+  });
 });

--- a/src/android-interface/android-interface.ts
+++ b/src/android-interface/android-interface.ts
@@ -1,5 +1,5 @@
 import { defaultsDeep } from 'lodash';
-import { AppEventPayload, AppEventPayloadOptions, AppEventPayloadVersion } from './types';
+import { AppEventPayload, AppEventPayloadMetadata, AppEventPayloadOptions, AppEventPayloadVersion } from './types';
 import { ValidateV1Schema } from './schema-validators';
 
 export interface AndroidInterfaceOptions {
@@ -7,6 +7,7 @@ export interface AndroidInterfaceOptions {
   app_id: string;
   cr_user_id: string;
   version?: AppEventPayloadVersion;
+  metadata?: AppEventPayloadMetadata;
   debug?: boolean;
   log?: boolean;
 }
@@ -103,13 +104,15 @@ export class AndroidInterface {
     const {
       cr_user_id,
       app_id,
-      version
+      version,
+      metadata
     } = this.options;
 
     return {
       cr_user_id,
       app_id,
-      schema_version: version ?? DEFAULT_OPTIONS.version!
+      schema_version: version ?? DEFAULT_OPTIONS.version!,
+      metadata
     };
   }
 

--- a/src/android-interface/schema-validators.ts
+++ b/src/android-interface/schema-validators.ts
@@ -11,5 +11,6 @@ export const ValidateV1Schema = z.object({
   app_id: requiredString('App ID'),
   collection: requiredString('Collection'),
   data: z.record(z.string(), z.any()),
+  metadata: z.record(z.string(), z.any()).optional(),
   timestamp: requiredString('Event ISO-8601 timestamp')
 });

--- a/src/android-interface/types.d.ts
+++ b/src/android-interface/types.d.ts
@@ -8,11 +8,23 @@ export interface AppEventPayloadOptions {
   [key: string]: PayloadProcessingInstruction
 }
 
+/**
+ * Cross-cutting metadata attached to every payload, kept separate from the
+ * event-specific `data`. The sub-app sets `appVersion`; the Android container
+ * adds `container_app_version` on receipt.
+ */
+export interface AppEventPayloadMetadata {
+  /** Sub-app's own version. Mirrors the Firebase `event_params.appVersion`. */
+  appVersion?: string;
+  [key: string]: any;
+}
+
 export interface AppEventPayload {
   cr_user_id: string;
   app_id: string;
   collection: AppEventPayloadCollection;
   data: any;
   options?: AppEventPayloadOptions;
+  metadata?: AppEventPayloadMetadata;
   timestamp: string;
 }


### PR DESCRIPTION
# Changes
- Add an optional top-level metadata object to AppEventPayload (typed AppEventPayloadMetadata with appVersion? + open-ended keys) — cross-cutting version info now lives here instead of inside data.
- AndroidInterface accepts metadata in its constructor options; getBaseParams() attaches it to every payload, so both logSummaryData and logUserSessionsData carry it without per-call arguments.

# How to test
- Verified end-to-end via npm link into FTM and Assessment + the CRContainer debug build: Firestore docs show metadata.appVersion (and the container-stamped metadata.container_app_version).

Ref: [MR-97](https://curiouslearning.atlassian.net/browse/MR-97)


[MR-97]: https://curiouslearning.atlassian.net/browse/MR-97?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Developers can now provide optional metadata during initialization, which will be automatically included in event payloads. Supports application version and custom key-value pairs.

* **Tests**
  * Comprehensive tests added to verify metadata is correctly attached to event payloads and that payloads remain backward-compatible when metadata is not provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->